### PR TITLE
feat: add new activeLoops getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 - API-Friendly
 
 <blockquote>
-  <sub><strong>Package size</strong>: <code>~1.44 KB</code> minified, <code>~790 B</code> gzip</sub>
+  <sub><strong>Package size</strong>: <code>~1.54 KB</code> minified, <code>~855 B</code> gzip</sub>
 </blockquote>
 
 ## Core Concepts
@@ -230,6 +230,9 @@ By default, the callback will only be executed once.
 
 ```ts
 frame.update((state) => console.log(state), { loop: true })
+
+// The number of active frame loops can also be accessed via the `.activeLoops` getter
+console.log(frame.activeLoops)
 ```
 
 ### schedule

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,18 @@ export type Frame<T extends string> = {
    * ```
    */
   get state(): Readonly<FrameState>
+  /**
+   * Provides a read-only number of active frame loops at any given point.
+   *
+   * Useful for debugging and monitoring or for dynamic actions.
+   *
+   * @example
+   *
+   * ```ts
+   * frame.activeLoops
+   * ```
+   */
+  get activeLoops(): Readonly<number>
 } & FramePhases<T>
 
 export type TickerIDs = 'raf' | 'timeout'


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [x] Types
- [x] Documentation

## Request Description

Improves loop storage performance via `WeakSet`, and also exposes the `activeLoops` getter publicly.

### activeLoops

Provides a read-only number of active frame loops at any given point.

Useful for debugging and monitoring or for dynamic actions.

```ts
console.log(frame.activeLoops)
```