### PR TITLE
feat: add new compact frame manager

### DIFF
--- a/bundler.config.ts
+++ b/bundler.config.ts
@@ -2,19 +2,46 @@ import { defineConfig } from '@hypernym/bundler'
 
 export default defineConfig({
   entries: [
-    { input: './src/index.ts' },
-    { input: './src/index.ts', output: './dist/index.min.mjs', minify: true },
-    { dts: './src/types.ts', output: './dist/index.d.mts' },
+    // Main
+    { input: './src/frame/index.ts', output: './dist/index.mjs' },
     {
-      input: './src/index.ts',
+      input: './src/frame/index.ts',
+      output: './dist/index.min.mjs',
+      minify: true,
+    },
+    { dts: './src/frame/types.ts', output: './dist/index.d.mts' },
+    {
+      input: './src/frame/index.ts',
       output: './dist/index.iife.js',
       name: 'Frame',
       format: 'iife',
       minify: true,
     },
     {
-      input: './src/index.ts',
+      input: './src/frame/index.ts',
       output: './dist/index.umd.js',
+      name: 'Frame',
+      format: 'umd',
+      minify: true,
+    },
+    // Compact
+    { input: './src/compact/index.ts', output: './dist/compact/index.mjs' },
+    {
+      input: './src/compact/index.ts',
+      output: './dist/compact/index.min.mjs',
+      minify: true,
+    },
+    { dts: './src/compact/types.ts', output: './dist/compact/index.d.mts' },
+    {
+      input: './src/compact/index.ts',
+      output: './dist/compact/index.iife.js',
+      name: 'Frame',
+      format: 'iife',
+      minify: true,
+    },
+    {
+      input: './src/compact/index.ts',
+      output: './dist/compact/index.umd.js',
       name: 'Frame',
       format: 'umd',
       minify: true,

--- a/src/compact/index.ts
+++ b/src/compact/index.ts
@@ -1,0 +1,198 @@
+import { defaultState } from './utils'
+import type {
+  Phase,
+  PhaseIDs,
+  PhaseCallback,
+  PhaseScheduleOptions,
+  FrameState,
+  FrameOptions,
+  Frame,
+} from './types'
+
+/**
+ * Creates a compact `frame` manager.
+ *
+ * @example
+ *
+ * ```ts
+ * import { createFrame } from '@hypernym/frame/compact'
+ *
+ * const frame = createFrame()
+ *
+ * frame.update((state) => console.log(state), { loop: true })
+ * ```
+ *
+ * @see [Repository](https://github.com/hypernym-studio/frame)
+ */
+export function createFrame<T extends string = PhaseIDs>(
+  options: FrameOptions<T> = {},
+): Frame<T> {
+  let {
+    phases: framePhases = ['read', 'update', 'render'] as T[],
+    scheduler = typeof window !== 'undefined'
+      ? requestAnimationFrame
+      : () => {},
+    allowLoop = true,
+    fps,
+  } = options
+
+  const phases = {} as Record<T, Phase>
+
+  let loops = new WeakSet<PhaseCallback>()
+  let activeLoops = 0
+
+  let shouldRunFrame = false
+  let isStopped = false
+
+  const frameInterval = 1000 / (fps || 60)
+  const maxDeltaTime = 40
+  let lastFrameTime = 0
+  let lastPauseTime: number | null = null
+  let totalPausedTime = 0
+
+  let state: FrameState = defaultState()
+
+  const phase = (callback: (id: Phase) => void): void =>
+    framePhases.forEach((id) => callback(phases[id]))
+
+  const createPhase = (): Phase => {
+    let thisFrame = new Set<PhaseCallback>()
+    let nextFrame = new Set<PhaseCallback>()
+
+    let isRunning = false
+    let flushNextFrame = false
+
+    const runPhaseCallback = (callback: PhaseCallback): void => {
+      if (loops.has(callback)) phase.schedule(callback)
+      callback(state)
+    }
+
+    const phase: Phase = {
+      schedule: (
+        callback: PhaseCallback,
+        { loop, schedule = true }: PhaseScheduleOptions = {},
+      ): PhaseCallback => {
+        const queue = isRunning && !schedule ? thisFrame : nextFrame
+        if (loop) {
+          if (!loops.has(callback)) activeLoops++
+          loops.add(callback)
+        }
+        if (!queue.has(callback)) queue.add(callback)
+        return callback
+      },
+      run: (state: FrameState): void => {
+        if (isRunning) {
+          flushNextFrame = true
+          return
+        }
+
+        isRunning = true
+        ;[thisFrame, nextFrame] = [nextFrame, thisFrame]
+        thisFrame.forEach(runPhaseCallback)
+        thisFrame.clear()
+        isRunning = false
+
+        if (flushNextFrame) {
+          flushNextFrame = false
+          phase.run(state)
+        }
+      },
+      cancel: (callback?: PhaseCallback): void => {
+        if (!callback) {
+          thisFrame.clear()
+          nextFrame.clear()
+          return
+        }
+        nextFrame.delete(callback)
+        if (loops.has(callback)) activeLoops--
+        loops.delete(callback)
+      },
+    }
+    return phase
+  }
+
+  const runFrame = (): void => {
+    if (isStopped) return
+
+    const now = performance.now()
+    const time = now - totalPausedTime
+
+    shouldRunFrame = activeLoops > 0
+
+    if (fps) {
+      const delta = time - lastFrameTime
+      if (delta < frameInterval) {
+        if (!isStopped) scheduler(runFrame)
+        return
+      }
+      lastFrameTime = time - (delta % frameInterval)
+      state.delta = frameInterval
+    } else {
+      state.delta =
+        state.timestamp === 0
+          ? frameInterval
+          : Math.min(Math.max(time - state.timestamp, 1), maxDeltaTime)
+      lastFrameTime = time
+    }
+
+    state.timestamp = time
+    state.isRunning = true
+    phase((id) => id.run(state))
+    state.isRunning = false
+
+    if (shouldRunFrame && allowLoop && !isStopped) scheduler(runFrame)
+  }
+
+  const frame: Frame<T> = {
+    start: (): void => {
+      if (isStopped && shouldRunFrame) {
+        isStopped = false
+        const now = performance.now()
+        if (lastPauseTime) {
+          totalPausedTime += now - lastPauseTime
+          lastPauseTime = null
+        }
+        lastFrameTime = now - totalPausedTime
+        state.timestamp = lastFrameTime
+        scheduler(runFrame)
+      }
+    },
+    stop: (): void => {
+      if (!isStopped) {
+        isStopped = true
+        lastPauseTime = performance.now()
+      }
+    },
+    cancel: (callback?: PhaseCallback): void => {
+      if (!callback) {
+        state = defaultState()
+        loops = new WeakSet()
+        activeLoops = 0
+        phase((id) => id.cancel())
+        shouldRunFrame = false
+        return
+      }
+      phase((id) => id.cancel(callback))
+    },
+    get state(): Readonly<FrameState> {
+      return state
+    },
+  } as Frame<T>
+
+  framePhases.forEach((id) => {
+    phases[id] = createPhase()
+    frame[id] = ((
+      callback: PhaseCallback,
+      options: PhaseScheduleOptions = {},
+    ) => {
+      if (!shouldRunFrame) {
+        shouldRunFrame = true
+        lastFrameTime = performance.now()
+        scheduler(runFrame)
+      }
+      return phases[id].schedule(callback, options)
+    }) as Frame<T>[T]
+  })
+
+  return frame
+}

--- a/src/compact/types.ts
+++ b/src/compact/types.ts
@@ -1,0 +1,45 @@
+export type PhaseIDs = 'read' | 'update' | 'render'
+
+export type PhaseCallback = (state: FrameState) => void
+
+export interface PhaseScheduleOptions {
+  loop?: boolean
+  schedule?: boolean
+}
+
+export type PhaseSchedule = (
+  callback: PhaseCallback,
+  options?: PhaseScheduleOptions,
+) => PhaseCallback
+
+export interface Phase {
+  schedule: PhaseSchedule
+  run: (state: FrameState) => void
+  cancel: (callback?: PhaseCallback) => void
+}
+
+export interface FrameState {
+  delta: number
+  timestamp: number
+  isRunning: boolean
+}
+
+export type FramePhases<T extends string> = {
+  [K in T]: PhaseSchedule
+}
+
+export type Frame<T extends string> = {
+  start: () => void
+  stop: () => void
+  cancel: (callback?: PhaseCallback) => void
+  get state(): Readonly<FrameState>
+} & FramePhases<T>
+
+export interface FrameOptions<T extends string> {
+  phases?: T[]
+  scheduler?: (callback: VoidFunction) => number | void
+  allowLoop?: boolean
+  fps?: number | false
+}
+
+export * from './'

--- a/src/compact/utils.ts
+++ b/src/compact/utils.ts
@@ -1,0 +1,7 @@
+import type { FrameState } from './types'
+
+export const defaultState = (): FrameState => ({
+  delta: 0.0,
+  timestamp: 0.0,
+  isRunning: false,
+})


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [x] Types

## Request Description

> [!NOTE]
>
> This is still an experimental version so it is not currently recommended for production, but it will most likely be the default version in the first official release.

Adds a compact `frame` manager.

```ts
import { createFrame } from '@hypernym/frame/compact'

const frame = createFrame()

const onUpdate = frame.update((state) => console.log(state), { loop: true })

// cancel the callback later in the code
// frame.cancel(onUpdate)

// or cancel the entire frame
// frame.cancel()
```

### Bundlesize

- **Compact**: `1.32 KB` minified, `734 B` gzip

### API

```ts
frame.read(callback, options)
frame.update(callback, options)
frame.render(callback, options)

frame.start()
frame.stop()
frame.cancel()

frame.state
```

### Scheduler

```ts
// use custom scheduler like `microtask`
const frame = createFrame({ scheduler: queueMicrotask, allowLoop: false })

// or `setTimeout`
const frame = createFrame({ scheduler: setTimeout, fps: 60 })

// default scheduler is `raf`
const frame = createFrame({ scheduler: requestAnimationFrame })
```

### Phases

```ts
// define custom phases
const frame = createFrame({ phases: ['measure', 'mutate'] })

frame.measure(callback, options)
frame.mutate(callback, options)

```