### PR TITLE
feat: add dynamic fps option

### DIFF
--- a/src/compact/index.ts
+++ b/src/compact/index.ts
@@ -44,7 +44,7 @@ export function createFrame<T extends string = PhaseIDs>(
   let shouldRunFrame = false
   let isStopped = false
 
-  const frameInterval = 1000 / (fps || 60)
+  let frameInterval = 1000 / 60
   const maxDeltaTime = 40
   let lastFrameTime = 0
   let lastPauseTime: number | null = null
@@ -176,6 +176,13 @@ export function createFrame<T extends string = PhaseIDs>(
     },
     get state(): Readonly<FrameState> {
       return state
+    },
+    get fps(): number | false | undefined {
+      return fps
+    },
+    set fps(v) {
+      frameInterval = 1000 / (v || 60)
+      fps = v
     },
   } as Frame<T>
 

--- a/src/compact/types.ts
+++ b/src/compact/types.ts
@@ -33,6 +33,8 @@ export type Frame<T extends string> = {
   stop: () => void
   cancel: (callback?: PhaseCallback) => void
   get state(): Readonly<FrameState>
+  get fps(): number | false | undefined
+  set fps(v: number | false | undefined)
 } & FramePhases<T>
 
 export interface FrameOptions<T extends string> {


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [x] Types

## Request Description

Adds the ability to dynamically set the `fps` limit. Super useful for situations where you need to set the fps after frame init.

```ts
const frame = createFrame()

console.log(frame.fps) // undefined

frame.fps = 60

console.log(frame.fps) // 60

frame.update((state) => console.log(state), { loop: true }) // runs at `60fps`
```

### Bundlesize

- **Compact**: `1.36 KB` minified, `753 B` gzip
