### PR TITLE
feat: add new process and phase system to compact frame

### DIFF
--- a/src/compact/types.ts
+++ b/src/compact/types.ts
@@ -1,21 +1,15 @@
-export type PhaseIDs = 'read' | 'update' | 'render'
+export type Process = (state: FrameState) => void
 
-export type PhaseCallback = (state: FrameState) => void
-
-export interface PhaseScheduleOptions {
+export interface ProcessOptions {
   loop?: boolean
+  phase?: number
   schedule?: boolean
 }
 
-export type PhaseSchedule = (
-  callback: PhaseCallback,
-  options?: PhaseScheduleOptions,
-) => PhaseCallback
-
 export interface Phase {
-  schedule: PhaseSchedule
-  run: (state: FrameState) => void
-  cancel: (callback?: PhaseCallback) => void
+  schedule(process: Process, options?: ProcessOptions): Process
+  add(state: FrameState): void
+  delete(process: Process): void
 }
 
 export interface FrameState {
@@ -24,23 +18,19 @@ export interface FrameState {
   isRunning: boolean
 }
 
-export type FramePhases<T extends string> = {
-  [K in T]: PhaseSchedule
+export interface Frame {
+  add(process: Process, options?: ProcessOptions): Process
+  delete(process?: Process): void
+  start(): void
+  stop(): void
+  get state(): Readonly<FrameState>
+  get fps(): number | false
+  set fps(v: number | false)
 }
 
-export type Frame<T extends string> = {
-  start: () => void
-  stop: () => void
-  cancel: (callback?: PhaseCallback) => void
-  get state(): Readonly<FrameState>
-  get fps(): number | false | undefined
-  set fps(v: number | false | undefined)
-} & FramePhases<T>
-
-export interface FrameOptions<T extends string> {
-  phases?: T[]
-  scheduler?: (callback: VoidFunction) => number | void
-  allowLoop?: boolean
+export interface FrameOptions {
+  scheduler?: (process: VoidFunction) => number | void
+  loop?: boolean
   fps?: number | false
 }
 

--- a/src/compact/utils.ts
+++ b/src/compact/utils.ts
@@ -1,7 +1,0 @@
-import type { FrameState } from './types'
-
-export const defaultState = (): FrameState => ({
-  delta: 0.0,
-  timestamp: 0.0,
-  isRunning: false,
-})


### PR DESCRIPTION
## Type of Change

- [x] New feature
- [x] Types

## Request Description

> [!NOTE]
>
> This is still an experimental version so it is not currently recommended for production, but it will most likely be the default version in the first official release.

### Bundlesize

- **Compact**: `1.37 KB` minified, `737 B` gzip


Restructures and simplifies the entire frame API. Performance is also improved through dynamic phase creation—phases are now created on demand, rather than strictly in advance as before.

```ts
import { createFrame } from '@hypernym/frame/compact'

const frame = createFrame()

const process = frame.add((state) => console.log(state), { loop: true }) // Adds the process

frame.delete(process) // Deletes a specific process

frame.add((state) => console.log(state), { phase: 1 }) // Adds the process to a specific phase (default is 0)

frame.delete() // Deletes all processes, phases and resets the frame state
```

### Before

```ts
// Phases
frame.read(cb)
frame.update(cb)
frame.render(cb)

// Cancel
frame.cancel(cb)
frame.cancel()
```

### Now

All phases are now unified under a single `.add()` method.

The default phase is `0`, and specifying a phase is optional. You can define an unlimited number of `phases`, though most use cases only require one or two — typically three: read (`0`), update (`1`), and render (`2`). Phases always run in strict numerical order, from the smallest to the largest.

```ts
// Phases
frame.add(process, { phase: -1 }) // runs before 0
frame.add(process) // default phase is 0
frame.add(process, { phase: 1 }) // runs after 0
frame.add(process, { phase: 2 }) // runs after 1
// etc ...

// Delete
frame.delete(process)
frame.delete()

// all other options, methods, getters, setters are the same
frame.start()
frame.stop()
frame.state
frame.fps
```
