### PR TITLE
break: remove fps controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <pre align="center">pnpm add @hypernym/frame</pre>
 
 <p align="center">
-  <sub>Size: <code>~1.34 KB</code> min, <code>~0.73 KB</code> gzip</sub>
+  <sub>Size: <code>~1.01 KB</code> min, <code>~0.58 KB</code> gzip</sub>
 </p>
 
 <br>
@@ -37,8 +37,6 @@
 - Dynamic Phases
 - Strict Queue Order
 - Custom Scheduler
-- Frame Controls
-- FPS Managment
 - Frame State
 - Modular Code
 - Type-safe
@@ -110,7 +108,7 @@ const process = frame.add(
 )
 ```
 
-Each phase is executed in strictly ascending numerical order.
+Phases always run from the lowest number to the highest.
 
 ```ts
 frame.add(() => console.log('Phase 2: Render'), { phase: 2 })
@@ -137,85 +135,69 @@ Phase 2: Render
 ```ts
 import { createFrame } from '@hypernym/frame'
 
-// Frame
+// Main Frame
 const frame = createFrame(options)
 
-// Phases
+// Methods
 frame.add(process, options)
 frame.delete(process)
-frame.delete()
 
-// Controls
-frame.start()
-frame.stop()
-
-// Getters/Setters
+// Getters
 frame.state
-frame.fps
 ```
 
-### add
+## add
 
-- Type: `(process: Process, options?: ProcessOptions): Process`
+- Type: `(process: FrameProcess, options?: FrameProcessOptions): FrameProcess`
 
 Adds a specific process to the frame update cycle.
 
-By default, the process will be executed only once.
+> [!NOTE]
+>
+> By default, the process will be executed only once (phase: `0`).
 
 ```ts
 frame.add(process, options)
 ```
 
-### delete
-
-- Type: `(process?: Process): void`
-
-Deletes a specific process from the frame update cycle.
-
-```ts
-frame.delete(process) // Deletes a specific process
-frame.delete() // Deletes all processes, phases and resets the frame state
-```
-
-### start
-
-- Type: `(): void`
-
-Starts the entire frame loop.
-
-```ts
-frame.start()
-```
-
-### stop
-
-- Type: `(): void`
-
-Stops the entire frame loop.
-
-```ts
-frame.stop()
-```
-
-### loop
+## loop
 
 - Type: `boolean`
 - Default: `undefined`
 
 Specifies whether the phase process should continue to repeat, without stopping after the first execution.
 
+> [!NOTE]
+>
+> Repeating processes need to be removed manually using the `frame.delete(process)` method.
+
 ```ts
 frame.add((state) => console.log(state), { loop: true })
 ```
 
-### phase
+## delete
+
+- Type: `(process?: FrameProcess): void`
+
+Deletes a specific process from the frame update cycle.
+
+> [!NOTE]
+>
+> Calling `frame.delete()` without the `process` parameter resets the main `frame` instance, resulting in the deletion of all processes, phases, and state.
+
+```ts
+frame.delete(process) // Deletes a specific process
+frame.delete() // Deletes all processes, phases and resets the frame state
+```
+
+## phase
 
 - Type: `number`
 - Default: `0`
 
 Specifies a custom frame phase.
 
-Phases always run in strictly ascending numerical order.
+Phases are processed in ascending numerical order, meaning lower run before higher ones.
 
 ```ts
 frame.add(process, { phase: -1 }) // Runs before 0
@@ -225,26 +207,26 @@ frame.add(process, { phase: 2 }) // Runs after 1
 // ...
 ```
 
-### schedule
+## immediate
 
 - Type: `boolean`
-- Default: `true`
+- Default: `undefined`
 
-Specifies the scheduling behavior.
+Controls the scheduling behavior.
 
-By default, the process waits for the next loop cycle. If disabled, it cancels the scheduling to the next frame and executes at the end of the current frame.
+By default, the process is scheduled to the next loop cycle. When enabled, it skips scheduling and executes at the end of the current frame.
 
 ```ts
 let index = 0
 
 frame.add(() => {
   index++
-  frame.add(() => index++, { schedule: false })
+  frame.add(() => index++, { immediate: true })
 })
 frame.add(() => console.log('Index: ', index), { phase: 1 }) // => Index 2
 ```
 
-### state
+## state
 
 - Type: `object`
 
@@ -266,7 +248,7 @@ console.log(frame.state)
 
 Specifies the scheduling system for the frame cycle.
 
-Determines how the frame updates are processed, whether through the `requestAnimationFrame`, `setTimeout` or `microtask`.
+Determines how the frame updates are processed, whether through the `requestAnimationFrame` or `microtask`.
 
 ```ts
 import { createFrame } from '@hypernym/frame'
@@ -274,22 +256,17 @@ import { createFrame } from '@hypernym/frame'
 const frame = createFrame({ scheduler: queueMicrotask, loop: false })
 ```
 
-### fps
+### loop
 
-- Type: `number`
-- Default: `undefined`
+- Type: `boolean`
+- Default: `true`
 
-Specifies a fixed rate for the frame update cycle.
-
-By default, the frame runs as fast as possible (typically tied to the `raf` cycle, which is usually 60 FPS or higher).
+Specifies global looping across all processes.
 
 ```ts
 import { createFrame } from '@hypernym/frame'
 
-const frame = createFrame({ fps: 60 })
-
-// Specifies the `fps` via setter
-frame.fps = 60
+const frame = createFrame({ loop: false })
 ```
 
 ## License

--- a/playground/index.html
+++ b/playground/index.html
@@ -22,7 +22,6 @@
   <body>
     <main>
       <h1>Frame Playground</h1>
-      <p class="state"></p>
     </main>
     <script type="module" src="./src/main.ts"></script>
   </body>

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -1,62 +1,51 @@
 import { createFrame } from '@'
 
-const frame = createFrame({ fps: 30 })
+const frame = createFrame()
 
-const handleVisibilityChange = (): void => {
-  if (document.hidden) frame.stop()
-  else frame.start()
-}
+frame.add(({ timestamp, delta, isRunning }) => {
+  console.log('Run once (1)', timestamp, delta, isRunning)
 
-document.addEventListener('visibilitychange', handleVisibilityChange)
+  frame.add(({ timestamp, delta, isRunning }) => {
+    console.log('Run once (3)', timestamp, delta, isRunning)
+  })
+})
 
-const el = document.querySelector('.state') as HTMLElement
+frame.add(({ timestamp, delta, isRunning }) => {
+  console.log('Run once (2)', timestamp, delta, isRunning)
 
-frame.add(() => console.log('Phase 2: Render'), { phase: 2 })
-frame.add(() => console.log('Phase 1: Update'), { phase: 1 })
-frame.add(() => console.log('Phase 0: Read'))
-frame.add(() => console.log('Phase 2: Render'), { phase: 2 })
-frame.add(() => console.log('Phase 0: Read'))
+  frame.add(({ timestamp, delta, isRunning }) => {
+    console.log('Run once (4)', timestamp, delta, isRunning)
+  })
+})
 
-let updateIndex: number = 0
-let updateStartTime: number = 0
+let resolve: (value: boolean) => void
 
-const onUpdate = frame.add(
-  (state) => {
-    console.log('Phase 1: Update Loop')
+const completed = new Promise((res) => {
+  resolve = res
+})
 
-    updateIndex++
-    const elapsed = state.timestamp - updateStartTime
+let index = 0
 
-    if (elapsed >= 1000) {
-      updateStartTime = state.timestamp
-    }
+const process = frame.add(
+  ({ timestamp, delta, isRunning }) => {
+    index++
 
-    if (updateIndex >= 100) frame.delete(onUpdate)
-  },
-  { loop: true, phase: 1 },
-)
+    console.log(`Loop (${index})`, timestamp, delta, isRunning)
 
-let renderStartTime = 0
-
-const lerp = (start: number, end: number, t: number): number =>
-  start + (end - start) * t
-
-const onRender = frame.add(
-  (state) => {
-    const elapsedTime = state.timestamp - renderStartTime
-    const progress = Math.min(elapsedTime / 4000, 1)
-    const position = lerp(0, 900, progress)
-
-    el.innerHTML = `${updateIndex} | ${parseFloat(state.timestamp.toFixed(0))}`
-    el.style.transform = `translateX(${position}px)`
-
-    if (position === 900) {
-      frame.delete(onRender)
-      console.log('Phase 2: Render Loop Done! ', frame.state)
-
-      frame.delete()
-      console.log('Frame cleared: ', frame.state)
+    if (index >= 33) {
+      frame.delete(process)
+      resolve(true)
     }
   },
-  { loop: true, phase: 2 },
+  { loop: true },
 )
+
+completed.then(() => {
+  console.log('Frame State', frame.state)
+
+  requestAnimationFrame(() => {
+    frame.add(({ timestamp, delta, isRunning }) => {
+      console.log('Run once (final)', timestamp, delta, isRunning)
+    })
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,24 +32,18 @@ export function createFrame(options: FrameOptions = {}): Frame {
   let {
     scheduler = typeof window !== 'undefined'
       ? requestAnimationFrame
-      : () => {},
+      : undefined,
     loop: allowLoop = true,
-    fps,
   } = options
 
-  const phases = new Map<number, FramePhase>()
   let order: number[] = []
-
-  let pending = 0
-  let activeLoops = 0
+  const phases = new Map<number, FramePhase>()
   let loops = new WeakSet<FrameProcess>()
 
-  const maxDeltaTime = 40
-  let frameInterval = 1000 / (fps || 60)
-  let lastTime = 0
-  let lastPauseTime = 0
-  let totalPausedTime = 0
-  let isStopped = false
+  const maxDelta = 40
+  let useDefaultDelta = true
+  let isScheduled = false
+  let runNextFrame = false
 
   const defaultState = (): FrameState => ({
     delta: 0,
@@ -67,9 +61,8 @@ export function createFrame(options: FrameOptions = {}): Frame {
 
     const runProcess = (process: FrameProcess): void => {
       if (allowLoop && loops.has(process)) {
+        runNextFrame = true
         phase.schedule(process, { loop: true })
-      } else if (pending > 0) {
-        pending--
       }
       process(state)
     }
@@ -77,15 +70,15 @@ export function createFrame(options: FrameOptions = {}): Frame {
     const phase: FramePhase = {
       schedule(
         process: FrameProcess,
-        { loop, schedule = true }: FrameProcessOptions = {},
+        { loop, immediate }: FrameProcessOptions = {},
       ): FrameProcess {
-        const queue = isRunning && !schedule ? thisFrame : nextFrame
-        if (!loop || !allowLoop) pending++
-        if (allowLoop && loop && !loops.has(process)) {
-          loops.add(process)
-          activeLoops++
-        }
+        const queue = immediate && isRunning ? thisFrame : nextFrame
+        const isLoop = allowLoop && loop
+
+        if (!isLoop) runNextFrame = true
+        if (isLoop && !loops.has(process)) loops.add(process)
         queue.add(process)
+
         return process
       },
       run(): void {
@@ -108,46 +101,38 @@ export function createFrame(options: FrameOptions = {}): Frame {
         }
       },
       delete(process: FrameProcess): void {
-        if (nextFrame.delete(process) && !loops.has(process) && pending > 0) {
-          pending--
-        }
-        if (allowLoop && loops.delete(process)) activeLoops--
+        nextFrame.delete(process)
+        loops.delete(process)
       },
     }
 
     return phase
   }
 
+  const scheduleFrame = (): void => {
+    if (!isScheduled) {
+      isScheduled = true
+      scheduler?.(runFrame)
+    }
+  }
+
   const runFrame = (): void => {
-    if (isStopped) return
+    isScheduled = runNextFrame = false
 
     const now = performance.now()
-    const time = now - totalPausedTime
 
-    if (fps) {
-      const delta = time - lastTime
-      if (delta < frameInterval) {
-        if (!isStopped) scheduler(runFrame)
-        return
-      }
-      lastTime = time - (delta % frameInterval)
-      state.delta = frameInterval
-    } else {
-      state.delta =
-        state.timestamp === 0
-          ? frameInterval
-          : Math.min(Math.max(time - state.timestamp, 1), maxDeltaTime)
-      lastTime = time
-    }
+    state.delta = useDefaultDelta
+      ? 1000 / 60
+      : Math.min(Math.max(now - state.timestamp, 1), maxDelta)
 
-    state.timestamp = time
+    state.timestamp = now
     state.isRunning = true
     order.forEach((p) => phases.get(p)?.run())
     state.isRunning = false
 
-    if ((allowLoop && activeLoops > 0) || pending > 0) {
-      scheduler(runFrame)
-    }
+    useDefaultDelta = !runNextFrame
+
+    if (runNextFrame) scheduleFrame()
   }
 
   return {
@@ -155,6 +140,7 @@ export function createFrame(options: FrameOptions = {}): Frame {
       process: FrameProcess,
       { phase = 0, ...opts }: FrameProcessOptions = {},
     ): FrameProcess {
+      if (!scheduler) return () => {}
       let p = phases.get(phase)
       if (!p) {
         order.push(phase)
@@ -162,48 +148,19 @@ export function createFrame(options: FrameOptions = {}): Frame {
         p = createPhase()
         phases.set(phase, p)
       }
-      if (pending === 0 && activeLoops === 0) {
-        lastTime = performance.now()
-        scheduler(runFrame)
-      }
-      return p.schedule(process, { phase, ...opts })
+      if (!state.isRunning) scheduleFrame()
+      return p.schedule(process, opts)
     },
     delete(process?: FrameProcess): void {
-      if (process) return phases.forEach((id) => id.delete(process))
+      if (process) return phases.forEach((p) => p.delete(process))
       phases.clear()
       order = []
       loops = new WeakSet()
       state = defaultState()
-      pending = activeLoops = lastTime = lastPauseTime = totalPausedTime = 0
-      isStopped = false
-    },
-    start(): void {
-      if (isStopped) {
-        isStopped = false
-        const now = performance.now()
-        if (lastPauseTime) {
-          totalPausedTime += now - lastPauseTime
-          lastPauseTime = 0
-        }
-        state.timestamp = lastTime = now - totalPausedTime
-        scheduler(runFrame)
-      }
-    },
-    stop(): void {
-      if (!isStopped) {
-        isStopped = true
-        lastPauseTime = performance.now()
-      }
+      isScheduled = runNextFrame = false
     },
     get state(): Readonly<FrameState> {
       return state
-    },
-    get fps(): number {
-      return fps || Infinity
-    },
-    set fps(v) {
-      frameInterval = 1000 / (v || 60)
-      fps = v
     },
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export type FrameProcess = (state: FrameState) => void
 export interface FrameProcessOptions {
   loop?: boolean
   phase?: number
-  schedule?: boolean
+  immediate?: boolean
 }
 
 export interface FramePhase {
@@ -21,17 +21,12 @@ export interface FrameState {
 export interface Frame {
   add(process: FrameProcess, options?: FrameProcessOptions): FrameProcess
   delete(process?: FrameProcess): void
-  start(): void
-  stop(): void
   get state(): Readonly<FrameState>
-  get fps(): number
-  set fps(v: number)
 }
 
 export interface FrameOptions {
   scheduler?: (process: VoidFunction) => number | void
   loop?: boolean
-  fps?: number
 }
 
 export * from '@'

--- a/test/frame.test.ts
+++ b/test/frame.test.ts
@@ -85,7 +85,7 @@ describe('Frame Manager', () => {
 
       frame.add(() => {
         index++
-        frame.add(() => index++, { schedule: false })
+        frame.add(() => index++, { immediate: true })
       })
       frame.add(() => (index === 2 ? resolve() : reject()), { phase: 1 })
     })


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated. -->

## Type of Change

<!-- Check the boxes with an 'x' that refers to your changes. -->

- [x] Breaking change
- [x] Types
- [x] Refactoring Code
- [x] Tests
- [x] Documentation

## Request Description

Removes `fps` limit and controls in favor of an external driver. It also simplifies the code and reduce final size.

### Previous API

```ts
export interface FrameProcessOptions {
  loop?: boolean
  phase?: number
  schedule?: boolean
}

interface FrameOptions {
  scheduler?: (process: VoidFunction) => number | void
  loop?: boolean
  fps?: number
}

interface Frame {
  add(process: FrameProcess, options?: FrameProcessOptions): FrameProcess
  delete(process?: FrameProcess): void
  start(): void
  stop(): void
  get state(): Readonly<FrameState>
  get fps(): number
  set fps(v: number)
}
```

### New API

```ts
export interface FrameProcessOptions {
  loop?: boolean
  phase?: number
  immediate?: boolean // renamed option `schedule` -> `immediate`
}

interface FrameOptions {
  scheduler?: (process: VoidFunction) => number | void
  loop?: boolean
  // removed fps limit
}

interface Frame {
  add(process: FrameProcess, options?: FrameProcessOptions): FrameProcess
  delete(process?: FrameProcess): void
  get state(): Readonly<FrameState>
  // removed fps controls
}
```
